### PR TITLE
Handle wifi_summary arrays from Supabase and add null-safe UI

### DIFF
--- a/Projects/IsTheWifiGood/src/app/page.tsx
+++ b/Projects/IsTheWifiGood/src/app/page.tsx
@@ -9,9 +9,10 @@ import DatabaseTest from '@/components/DatabaseTest'
 import { Badge } from '@/components/ui/badge'
 import { supabase, type Tables } from '@/lib/supabase'
 
+type WifiSummaryProp = Tables<'wifi_summaries'>
 type Hotel = Tables<'hotels'> & {
   city: Tables<'cities'>
-  wifi_summary?: Tables<'wifi_summaries'>
+  wifi_summary?: WifiSummaryProp | null
 }
 
 export default function Home() {
@@ -32,7 +33,14 @@ export default function Home() {
           .order('name')
 
         if (error) throw error
-        setFeaturedHotels((data as Hotel[]) || [])
+        // Process the data to handle wifi_summary arrays
+        const processedData = data?.map(hotel => ({
+          ...hotel,
+          wifi_summary: Array.isArray(hotel.wifi_summary) 
+            ? hotel.wifi_summary[0] 
+            : hotel.wifi_summary
+        })) || []
+        setFeaturedHotels(processedData as Hotel[])
       } catch (error) {
         console.error('Error fetching hotels:', error)
       } finally {

--- a/Projects/IsTheWifiGood/src/components/DatabaseTest.tsx
+++ b/Projects/IsTheWifiGood/src/components/DatabaseTest.tsx
@@ -11,7 +11,7 @@ type WifiSummary = Tables<'wifi_summaries'>
 
 interface HotelWithRelations extends Hotel {
   city: City
-  wifi_summary?: WifiSummary
+  wifi_summary?: WifiSummary | WifiSummary[] | null
 }
 
 export default function DatabaseTest() {
@@ -47,7 +47,14 @@ export default function DatabaseTest() {
           .order('name')
 
         if (hotelsError) throw hotelsError
-        setHotels((hotelsData as HotelWithRelations[]) || [])
+        // Process the data to handle wifi_summary arrays
+        const processedHotels = hotelsData?.map(hotel => ({
+          ...hotel,
+          wifi_summary: Array.isArray(hotel.wifi_summary) 
+            ? hotel.wifi_summary[0] 
+            : hotel.wifi_summary
+        })) || []
+        setHotels(processedHotels as HotelWithRelations[])
 
       } catch (err) {
         console.error('Database test error:', err)
@@ -122,7 +129,7 @@ export default function DatabaseTest() {
             <div key={hotel.id} className="p-4 border rounded-lg">
               <div className="flex justify-between items-start mb-2">
                 <h5 className="font-medium text-sm">{hotel.name}</h5>
-                {hotel.wifi_summary && hotel.wifi_summary.speed_tier && (
+                {hotel.wifi_summary && !Array.isArray(hotel.wifi_summary) && hotel.wifi_summary.speed_tier && (
                   <Badge 
                     className="text-xs"
                     style={{ 
@@ -140,13 +147,13 @@ export default function DatabaseTest() {
                 {hotel.hotel_chain && ` • ${hotel.hotel_chain}`}
               </div>
 
-              {hotel.wifi_summary && (
+              {hotel.wifi_summary && !Array.isArray(hotel.wifi_summary) && (
                 <div className="space-y-1">
                   <div className="flex justify-between text-xs">
                     <span>Score:</span>
-                    <span className="font-medium">{hotel.wifi_summary.overall_score}/5</span>
+                    <span className="font-medium">{hotel.wifi_summary.overall_score != null ? `${hotel.wifi_summary.overall_score}/5` : 'N/A'}</span>
                   </div>
-                  {hotel.wifi_summary.estimated_speed_mbps && (
+                  {hotel.wifi_summary.estimated_speed_mbps !== null && hotel.wifi_summary.estimated_speed_mbps !== undefined && (
                     <div className="flex justify-between text-xs">
                       <span>Speed:</span>
                       <span className="font-medium">{hotel.wifi_summary.estimated_speed_mbps} Mbps</span>

--- a/Projects/IsTheWifiGood/src/components/ui/hotel-card.tsx
+++ b/Projects/IsTheWifiGood/src/components/ui/hotel-card.tsx
@@ -11,20 +11,20 @@ interface HotelCardProps {
   hotel: {
     id: string
     name: string
-    address?: string
-    star_rating?: number
-    hotel_chain?: string
+    address?: string | null
+    star_rating?: number | null
+    hotel_chain?: string | null
     city: {
       name: string
       flag_emoji: string
     }
     wifi_summary?: {
       speed_tier: string
-      overall_score?: number
-      estimated_speed_mbps?: number
-      business_suitable?: boolean
-      highlights?: string[]
-    }
+      overall_score?: number | null
+      estimated_speed_mbps?: number | null
+      business_suitable?: boolean | null
+      highlights?: any
+    } | null
   }
   href?: string
   className?: string
@@ -33,13 +33,13 @@ interface HotelCardProps {
 
 export default function HotelCard({ hotel, href, className, compact = false }: HotelCardProps) {
   const wifiQuality = hotel.wifi_summary ? getWiFiQuality(
-    hotel.wifi_summary.estimated_speed_mbps, 
-    hotel.wifi_summary.overall_score || undefined
+    hotel.wifi_summary.estimated_speed_mbps !== null ? hotel.wifi_summary.estimated_speed_mbps : undefined, 
+    hotel.wifi_summary.overall_score !== null ? hotel.wifi_summary.overall_score : undefined
   ) : 'moderate'
   
   const wifiStrength = hotel.wifi_summary ? getStrengthFromQuality(hotel.wifi_summary.speed_tier) : 3
 
-  const CardWrapper = href ? Link : 'div'
+  const CardWrapper: any = href ? Link : 'div'
   const cardProps = href ? { href } : {}
 
   return (
@@ -76,7 +76,7 @@ export default function HotelCard({ hotel, href, className, compact = false }: H
                       color: 'white'
                     }}
                   >
-                    {hotel.wifi_summary.overall_score?.toFixed(1) || 'N/A'}
+                    {hotel.wifi_summary.overall_score != null ? hotel.wifi_summary.overall_score.toFixed(1) : 'N/A'}
                   </Badge>
                   {hotel.wifi_summary.business_suitable && (
                     <div className="absolute -top-1 -right-1 w-3 h-3 bg-green-500 rounded-full animate-pulse-glow" />
@@ -102,7 +102,7 @@ export default function HotelCard({ hotel, href, className, compact = false }: H
                     color: 'white'
                   }}
                 >
-                  {hotel.wifi_summary.overall_score?.toFixed(1) || 'N/A'}
+                  {hotel.wifi_summary.overall_score != null ? hotel.wifi_summary.overall_score.toFixed(1) : 'N/A'}
                 </Badge>
               )}
             </div>
@@ -144,7 +144,7 @@ export default function HotelCard({ hotel, href, className, compact = false }: H
                 <div>
                   <span className="text-muted-foreground">Speed</span>
                   <p className="font-medium">
-                    {hotel.wifi_summary.estimated_speed_mbps ? 
+                    {hotel.wifi_summary.estimated_speed_mbps !== null && hotel.wifi_summary.estimated_speed_mbps !== undefined ? 
                       `${hotel.wifi_summary.estimated_speed_mbps} Mbps` : 
                       hotel.wifi_summary.speed_tier ? 
                         hotel.wifi_summary.speed_tier.charAt(0).toUpperCase() + hotel.wifi_summary.speed_tier.slice(1) :
@@ -161,9 +161,9 @@ export default function HotelCard({ hotel, href, className, compact = false }: H
               </div>
 
               {/* Highlights */}
-              {hotel.wifi_summary.highlights && hotel.wifi_summary.highlights.length > 0 && !compact && (
+              {hotel.wifi_summary.highlights && Array.isArray(hotel.wifi_summary.highlights) && hotel.wifi_summary.highlights.length > 0 && !compact && (
                 <div className="flex flex-wrap gap-1 mt-2">
-                  {hotel.wifi_summary.highlights.slice(0, 2).map((highlight, index) => (
+                  {hotel.wifi_summary.highlights.slice(0, 2).map((highlight: string, index: number) => (
                     <Badge 
                       key={index}
                       variant="outline" 


### PR DESCRIPTION
- Normalize wifi_summary to a single object: map results and pick first item when arrays are returned
- Update types to allow WifiSummary | WifiSummary[] | null; add WifiSummaryProp alias
- Make hotel props nullable (address, star_rating, hotel_chain) in hotel-card
- Add guards against arrays/nulls in UI; show N/A for missing scores and check speed fields explicitly
- Prevent runtime errors and improve rendering with inconsistent Supabase relation data